### PR TITLE
feat: add ConcatCDFDataset

### DIFF
--- a/src/CDFDatasets.jl
+++ b/src/CDFDatasets.jl
@@ -14,10 +14,11 @@ using DiskArrays: cat_disk
 
 const CDFType = CDF.DataType
 
-export CDFDataset, CDFVariable, ConcatCDFVariable
+export CDFDataset, CDFVariable, ConcatCDFVariable, ConcatCDFDataset
 export TT2000
 export CDFType, cdf_type
 export vattrib
+export dim
 export is_record_varying
 export sanitize
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -2,6 +2,10 @@ struct CDFDataset{A} <: AbstractCDFDataset
     source::A
 end
 
+struct ConcatCDFDataset{A} <: AbstractCDFDataset
+    sources::A
+end
+
 # https://github.com/SciQLop/CDFpp/blob/main/pycdfpp/__init__.py
 
 """
@@ -28,10 +32,10 @@ function PyCDFppDataset end
 # Base interface
 Base.keys(ds::CDFDataset) = keys(ds.source)
 Base.parent(ds::CDFDataset) = ds.source
-Base.getindex(ds::CDFDataset, name::String) = CDM.variable(ds, name)
+Base.getindex(ds::AbstractCDFDataset, name::String) = CDM.variable(ds, name)
 
 function Base.show(io::IO, ::MIME"text/plain", ds::AbstractCDFDataset)
-    invoke(show, Tuple{IO, AbstractDataset}, io, ds)
+    return invoke(show, Tuple{IO, AbstractDataset}, io, ds)
 end
 
 function Base.show(io::IO, ds::AbstractCDFDataset)
@@ -48,6 +52,7 @@ function Base.show(io::IO, ds::AbstractCDFDataset)
         length(varnames_list) > max_show && print(io, ", \u2026")
     end
     print(io, ")")
+    return
 end
 
 # CommonDataModel.jl interface methods
@@ -62,5 +67,19 @@ CDM.attribnames(ds::CDFDataset) = CDM.attribnames(ds.source)
 CDM.attrib(ds::CDFDataset, name::String) = CDM.attrib(ds.source, name)
 
 function CDM.name(ds::AbstractCDFDataset)
-    only(get(ds.attrib, "Logical_source", "/"))
+    return only(get(ds.attrib, "Logical_source", "/"))
+end
+
+function ConcatCDFDataset(sources::AbstractVector{<:AbstractString}; backend = :julia)
+    backend = Symbol(backend)
+    @assert backend in (:julia, :CommonDataFormat)
+    return ConcatCDFDataset(CDF.CDFDataset.(sources))
+end
+
+_parent1(ds::ConcatCDFDataset) = ds.sources[1]
+CDM.varnames(ds::ConcatCDFDataset) = CDM.varnames(_parent1(ds))
+CDM.attribnames(ds::ConcatCDFDataset) = CDM.attribnames(_parent1(ds))
+CDM.attrib(ds::ConcatCDFDataset, name::String) = CDM.attrib(_parent1(ds), name)
+function CDM.variable(ds::ConcatCDFDataset, name::Union{String, Symbol})
+    return ConcatCDFVariable(map(x -> x[name], ds.sources))
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -38,7 +38,7 @@ Load variable data as an array with fill values and invalid data replaced by `Na
 
 See also: [`replace_fillval_by_nan!`](@ref)
 """
-function sanitize(var::AbstractCDFVariable; replace_fillval = true, replace_invalid = true)
+function sanitize(var; replace_fillval = true, replace_invalid = true)
     A = Array(var)
     replace_fillval && replace_fillval_by_nan!(A)
     replace_invalid && begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,20 @@ end
     @test CDM.dimnames(var) == CDM.dimnames(var1)
 end
 
+@testset "ConcatCDFDataset" begin
+    files = [data_path("omni_coho1hr_merged_mag_plasma_20200501_v01.cdf"), data_path("omni_coho1hr_merged_mag_plasma_20200601_v01.cdf")]
+    ds1 = CDFDataset(files[1])
+    concat_ds = ConcatCDFDataset(files)
+
+    @test CDM.varnames(concat_ds) == CDM.varnames(ds1)
+    @test CDM.attribnames(concat_ds) == CDM.attribnames(ds1)
+    var = concat_ds["V"]
+    @test size(var) == (1464,)
+    @test var isa ConcatCDFVariable
+    @test CDM.variable(var, "V") == var
+    @test CDF.is_record_varying(var) == true
+end
+
 @testset "CDFDatasets.jl (ELFIN)" begin
     # Test file path
     elx_file = data_path("elb_l2_epdef_20210914_v01.cdf")


### PR DESCRIPTION
- Added ConcatCDFDataset type for concatenating multiple CDF datasets
- Implemented fast_concat_diskarray_block_io for improved read performance
- Added optimized Array conversion method for ConcatCDFVariable using direct concatenation
- Added support for accessing concatenated dimension variables through dim() function
- Exported new ConcatCDFDataset type and dim function
- Added variable() method to ConcatCDFVariable for accessing relate