### PR TITLE
perf: optimize dataset reconstruction and time-based indexing for concatenated variables

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -80,10 +80,11 @@ _parent1(ds::ConcatCDFDataset) = ds.sources[1]
 CDM.path(ds::ConcatCDFDataset) = CDM.path.(ds.sources)
 
 function CDM.variable(ds::ConcatCDFDataset, name::SymbolString; metadata = nothing)
-    var1 = _parent1(ds)[name]
+    ds1 = _parent1(ds)
+    var1 = ds1[name]
     return if is_record_varying(var1)
-        ConcatCDFVariable(map(x -> x[name], ds.sources); metadata)
+        ConcatCDFVariable(map(x -> x[name], ds.sources); metadata, parentdataset = ds)
     else
-        CDFVariable(name, var1, ds, metadata)
+        CDFVariable(name, var1, ds1, metadata)
     end
 end

--- a/src/subvariable.jl
+++ b/src/subvariable.jl
@@ -16,11 +16,11 @@ function find_indices(tdim::Vector, t0, t1)
     end
 end
 
-function DiskArrays.getindex_disk(var::AbstractCDFVariable, interval::Interval)
+function DiskArrays.getindex_disk(var::AbstractCDFVariable{T}, interval::Interval) where {T}
     t0, t1 = endpoints(interval)
     # Handle the case where the data itself is the dimension variable
-    return if eltype(var) <: AbstractDateTime
-        tdim = convert(Vector, var)
+    return if T <: AbstractDateTime
+        tdim = convert(Vector{T}, var)
         indices = find_indices(tdim, t0, t1)
         @view tdim[indices]
     else

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CDFDatasets = "075ae62b-f872-4368-b383-31e3aa6c3154"
+Chairmarks = "0ca39b1e-fe0b-4e98-acfc-b1656634c4de"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -1,0 +1,41 @@
+using CDFDatasets
+import CDFDatasets.CommonDataModel as CDM
+using Dates
+using DimensionalData
+using Chairmarks
+
+include("utils.jl")
+
+# Setup
+files = [
+    data_path("omni_coho1hr_merged_mag_plasma_20200501_v01.cdf"),
+    data_path("omni_coho1hr_merged_mag_plasma_20200601_v01.cdf"),
+]
+ds1 = CDFDataset(files[1])
+concat_ds = cdfopen(files)
+
+t0 = DateTime(2020, 05, 03)
+t1 = DateTime(2020, 05, 04)
+
+var = concat_ds["V"]
+subvar = var[t0 .. t1]
+vds = view(concat_ds, t0 .. t1)
+
+# DimArray creation benchmarks
+@info "full ConcatCDFVariable" (@b DimArray($var))
+@info "SubVariable (time-clipped)" @b DimArray($subvar)
+
+@info "from CDFDataset" @b DimArray($concat_ds["V"])
+@info "from ClippedCDFDataset view" @b DimArray($vds["V"])
+@info "from CDFDataset view" @b DimArray($concat_ds["V"][t0 .. t1])
+
+# Array materialization
+@info @b Array($concat_ds["Epoch"])
+@info @b Array($vds["Epoch"])
+
+# Dimension access
+@info @b CDM.dim($var, 1)
+@info @b CDM.dim($subvar, 1)
+
+# Dataset reconstruction
+@info @b CDM.dataset($var)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,15 @@
+using Downloads
+
+data_path(fname) = joinpath(pkgdir(CDFDatasets), "data", fname)
+
+# Download test data from URL and cache locally
+function download_test_data(url, filename = basename(url))
+    cache_dir = joinpath(pkgdir(CDFDatasets), "test", "data")
+    mkpath(cache_dir)
+    filepath = joinpath(cache_dir, filename)
+    if !isfile(filepath)
+        @info "Downloading test data: $filename"
+        Downloads.download(url, filepath)
+    end
+    return filepath
+end


### PR DESCRIPTION
Add parentdataset field to ConcatCDFVariable to cache dataset reference and avoid repeated reconstruction
