### PR TITLE
fix: materialize dims in DimArray conversion for SubCDFVariable

### DIFF
--- a/ext/CDFDatasetsDimensionalDataExt.jl
+++ b/ext/CDFDatasetsDimensionalDataExt.jl
@@ -13,11 +13,11 @@ dimtype(::Val{3}) = Z
 # handle multi-dimensional DEPENDs
 function format_dim(data, dimvar, i)
     DT = i == ndims(data) ? Ti : dimtype(Val(i))
-    values = if length(dimvar) == size(data, i)
-        dimvar isa AbstractCDFVariable ? vec(materialize(dimvar)) : dimvar
-    else
-        axes(data, i)
+    if dimvar isa Union{AbstractCDFVariable, SubCDFVariable} && length(dimvar) == size(data, i)
+        mat = materialize(dimvar)
+        return DT(vec(mat.data); metadata = mat.metadata)
     end
+    values = length(dimvar) == size(data, i) ? dimvar : axes(data, i)
     return DT(values)
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -19,8 +19,8 @@ function _show_limited(io::IO, var::AbstractCDFVariable)
     indent = " "^level
     delim = " × "
     attrs = CDM.attrib(var)
-    units = get(attrs, "UNITS", "")
-    field = get(attrs, "FIELDNAM", get(attrs, "CATDESC", ""))
+    units = strip(get(attrs, "UNITS", ""))
+    field = get(attrs, "CATDESC", get(attrs, "FIELDNAM", ""))
 
     printstyled(io, indent, CDM.name(var), color = CDM.variable_color[])
     print(io, " (", join(size(var), delim), ")")

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -58,6 +58,8 @@ Load the variable data from disk into memory.
 """
 materialize(var) =
     MaterializedCDFVariable(CDM.name(var), Array(var), CDM.dataset(var), var.metadata)
+materialize(var::SubCDFVariable) =
+    MaterializedCDFVariable(CDM.name(var), Array(var), CDM.dataset(var), CDM.attrib(parent(var)))
 
 is_virtual(var) = get(var.attrib, "VIRTUAL", nothing) == "TRUE"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,7 +95,10 @@ end
         vds = view(concat_ds, t0 .. t1)
         @test Array(vds["Epoch"])[1] == t0
         @test vds["V"] == concat_ds["V"][t0 .. t1]
-        @test DimArray(vds["V"]).dims[1] ⊆ t0 .. t1
+        da = DimArray(vds["V"])
+        @test da.dims[1] ⊆ t0 .. t1
+        @test parent(da) isa Array  # data materialized
+        @test parent(dims(da)[1].val) isa Vector  # dim materialized
 
         str = sprint(show, MIME("text/plain"), vds)
         @test occursin("View:", str)
@@ -175,28 +178,5 @@ end
     @test ds isa CDFDataset
 end
 
-@testset "CDFDataset show" begin
     ds = CDFDataset(data_path("omni_coho1hr_merged_mag_plasma_20200501_v01.cdf"))
-
-    # Test compact show
-    str = string(ds)
-    @test occursin("omni_coho1hr_merged_mag_plasma", str)
-    @test occursin("12 variables", str)
-
-    # Test MIME"text/plain" show
-    io = IOBuffer()
-    show(io, MIME"text/plain"(), ds)
-    str = String(take!(io))
-    @test occursin("Group: omni_coho1hr_merged_mag_plasma", str)
-    @test occursin("Data variables\n", str)
-
-    # Test limited MIME"text/plain" show
-    io = IOBuffer()
-    show(IOContext(io, :limit => true), MIME"text/plain"(), ds)
-    str = String(take!(io))
-    @test occursin("28 attributes: Project, Discipline", str)
-    @test occursin("Global attributes\n", str)
-
-    str = sprint(show, ds["BR"]; context = :limit => true)
-    @test str == "BR (744) dims=Epoch [BR (RTN); nT]"
-end
+include("test_show.jl")

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -1,0 +1,25 @@
+@testset "CDFDataset show" begin
+    ds = CDFDataset(data_path("omni_coho1hr_merged_mag_plasma_20200501_v01.cdf"))
+
+    # Test compact show
+    str = string(ds)
+    @test occursin("omni_coho1hr_merged_mag_plasma", str)
+    @test occursin("12 variables", str)
+
+    # Test MIME"text/plain" show
+    io = IOBuffer()
+    show(io, MIME"text/plain"(), ds)
+    str = String(take!(io))
+    @test occursin("Group: omni_coho1hr_merged_mag_plasma", str)
+    @test occursin("Data variables\n", str)
+
+    # Test limited MIME"text/plain" show
+    io = IOBuffer()
+    show(IOContext(io, :limit => true), MIME"text/plain"(), ds)
+    str = String(take!(io))
+    @test occursin("28 attributes: Project, Discipline", str)
+    @test occursin("Global attributes\n", str)
+
+    str = sprint(show, ds["BR"]; context = :limit => true)
+    @test str == "BR (744) dims=Epoch [BR in RTN (Radial-Tangential-Normal) coordinate system; nT]"
+end


### PR DESCRIPTION
`format_dim` previously left SubCDFVariable dims as lazy disk views when
converting to DimArray. Now uses `CDFVariableLike` union to materialize
both AbstractCDFVariable and SubCDFVariable dims via `vec(Array(dimvar))`.

Also unifies `dims` and `DimArray` method signatures to `CDFVariableLike`.
