### PR TITLE
fix: handle Interval indexing without relying on DiskArrays getindex_disk

### DIFF
--- a/src/CDFDatasets.jl
+++ b/src/CDFDatasets.jl
@@ -10,7 +10,7 @@ using Dates: unix2datetime, AbstractDateTime
 import CommonDataFormat as CDF
 import CommonDataFormat: is_record_varying
 import DiskArrays
-using DiskArrays: getindex_disk, AbstractDiskArray
+using DiskArrays: AbstractDiskArray
 using IntervalSets: endpoints, Interval, (..)
 
 const CDFType = CDF.DataType

--- a/src/materialize.jl
+++ b/src/materialize.jl
@@ -14,6 +14,8 @@ Base.getindex(var::CDFVariable{T, N, A}, name::Union{AbstractString, Symbol}) wh
     invoke(getindex, Tuple{AbstractVariable, Union{AbstractString, Symbol}}, var, name)
 Base.getindex(var::CDFVariable{T, N, <:Array}, name::CDM.CFStdName) where {T, N} =
     invoke(getindex, Tuple{Union{AbstractDataset, AbstractVariable}, CDM.CFStdName}, var, name)
+Base.getindex(var::CDFVariable{T, N, <:Array}, interval::Interval) where {T, N} =
+    _getindex_interval(var, interval)
 Base.copy(var::CDFVariable{T, N, <:Array}) where {T, N} = copy(var.data)
 
 for fname in (:sum, :prod, :all, :any, :minimum, :maximum)

--- a/src/subvariable.jl
+++ b/src/subvariable.jl
@@ -6,7 +6,7 @@ function find_indices(tdim::Vector, t0, t1)
     end
 end
 
-function DiskArrays.getindex_disk(var::CDFVariable{T}, interval::Interval) where {T}
+function _getindex_interval(var::CDFVariable{T}, interval::Interval) where {T}
     t0, t1 = endpoints(interval)
     # Handle the case where the data itself is the dimension variable
     return if T <: AbstractDateTime
@@ -19,3 +19,5 @@ function DiskArrays.getindex_disk(var::CDFVariable{T}, interval::Interval) where
         selectdim(var, ndims(var), indices)
     end
 end
+
+Base.getindex(var::CDFVariable, interval::Interval) = _getindex_interval(var, interval)


### PR DESCRIPTION
DiskArrays 0.4.20 ([#296](https://github.com/meggart/DiskArrays.jl/pull/296)) runs `checkbounds` on the raw index before dispatching to `getindex_disk`, so `var[t0 .. t1]` threw:

```
ArgumentError: unable to check bounds for indices of type IntervalSets.ClosedInterval{DateTime}
```

## Fix
An interval is a **value-based selection** returning a lazy subvariable — not a disk block read — so it belongs on `Base.getindex`, not `getindex_disk`:
- `Base.getindex(::CDFVariable, ::Interval)` → shared `_getindex_interval` helper (old `getindex_disk` body, unchanged logic).
- Array-backed disambiguation `Base.getindex(::CDFVariable{T,N,<:Array}, ::Interval)` to stay Aqua-ambiguity-free against the generic `I...` method.
- Dropped the now-unused `getindex_disk` import.

Decouples interval clipping from DiskArrays dispatch internals.

## Verification
- Full suite passes on DiskArrays 0.4.20 (interval/clip testsets + Aqua).
- Bisected: 0.4.19 OK, 0.4.20 broke it.

Upstream report: JuliaIO/DiskArrays.jl#298. Bump `0.2.0` → `0.2.1`. Unblocks JuliaSpacePhysics/CDAWeb.jl#30.